### PR TITLE
Support independent steering control

### DIFF
--- a/cfg/DiffDriveSteeringController.cfg
+++ b/cfg/DiffDriveSteeringController.cfg
@@ -15,5 +15,7 @@ gen.add("wheel_separation_multiplier", double_t, 0, "Wheel separation multiplier
 gen.add("publish_rate", double_t, 0, "Publish rate of odom.", 50.0, 0.0, 2000.0)
 gen.add("enable_odom_tf", bool_t, 0, "Publish odom frame to tf.", True)
 
+gen.add("enable_independent_steering", bool_t, 0, "If true, we can control the steerings independently.", True)
+
 exit(gen.generate(PACKAGE, "diff_drive_steering_controller", "DiffDriveSteeringController"))
 

--- a/include/diff_drive_steering_controller/diff_drive_steering_controller.h
+++ b/include/diff_drive_steering_controller/diff_drive_steering_controller.h
@@ -43,10 +43,13 @@
 #include <hardware_interface/joint_command_interface.h>
 #include <memory>
 #include <nav_msgs/Odometry.h>
+#include <std_msgs/Float64.h>
+#include <string>
 #include <pluginlib/class_list_macros.hpp>
 #include <realtime_tools/realtime_buffer.h>
 #include <realtime_tools/realtime_publisher.h>
 #include <tf/tfMessage.h>
+#include <unordered_map>
 
 namespace diff_drive_steering_controller{
 
@@ -132,6 +135,9 @@ namespace diff_drive_steering_controller{
     realtime_tools::RealtimeBuffer<Commands> command_;
     Commands command_struct_;
     ros::Subscriber sub_command_;
+    std::unordered_map<std::string, ros::Subscriber> sub_steering_command_;
+    std::unordered_map<std::string, double> steering_target_angle_;
+    bool enable_independent_steering_;
 
     /// Odometry related:
     std::shared_ptr<realtime_tools::RealtimePublisher<nav_msgs::Odometry> > odom_pub_;
@@ -233,6 +239,14 @@ namespace diff_drive_steering_controller{
      * \param command Velocity command message (twist)
      */
     void cmdVelCallback(const geometry_msgs::Twist& command);
+
+    /**
+     * \brief Steering command callback
+     *
+     * \param command Steering angle in radians.
+     * \param wheel_name "left" or "right"
+     */
+    void steeringCmdCallback(const std_msgs::Float64ConstPtr& command, const std::string& wheel_name);
 
     /**
      * \brief Get the wheel names from a wheel param

--- a/src/diff_drive_steering_controller.cpp
+++ b/src/diff_drive_steering_controller.cpp
@@ -178,10 +178,6 @@ namespace diff_drive_steering_controller{
 	controller_nh.param("left_steering", left_steering_name, left_steering_name);
 	controller_nh.param("right_steering", right_steering_name, right_steering_name);
 
-  const double steer_p = controller_nh.param("steer_p", 1.0);
-  const double steer_i = controller_nh.param("steer_i", 0.0);
-  const double steer_d = controller_nh.param("steer_d", 0.0);
-
     // Odometry related:
     double publish_rate;
     controller_nh.param("publish_rate", publish_rate, 50.0);

--- a/src/diff_drive_steering_controller.cpp
+++ b/src/diff_drive_steering_controller.cpp
@@ -152,6 +152,7 @@ namespace diff_drive_steering_controller{
     , base_frame_id_("base_link")
     , odom_frame_id_("odom")
     , enable_odom_tf_(true)
+    , enable_independent_steering_(true)
 	, steering_angle_absolute_value_limit_(M_PI/4.0)
   {
   }
@@ -176,6 +177,10 @@ namespace diff_drive_steering_controller{
 	controller_nh.param("right_wheel", right_wheel_name, right_wheel_name);
 	controller_nh.param("left_steering", left_steering_name, left_steering_name);
 	controller_nh.param("right_steering", right_steering_name, right_steering_name);
+
+  const double steer_p = controller_nh.param("steer_p", 1.0);
+  const double steer_i = controller_nh.param("steer_i", 0.0);
+  const double steer_d = controller_nh.param("steer_d", 0.0);
 
     // Odometry related:
     double publish_rate;
@@ -233,6 +238,9 @@ namespace diff_drive_steering_controller{
 
     controller_nh.param("enable_odom_tf", enable_odom_tf_, enable_odom_tf_);
     ROS_INFO_STREAM_NAMED(name_, "Publishing to tf is " << (enable_odom_tf_?"enabled":"disabled"));
+
+    controller_nh.param("enable_independent_steering", enable_independent_steering_, enable_independent_steering_);
+    ROS_INFO_STREAM_NAMED(name_, "Independent steering is " << (enable_independent_steering_?"enabled":"disabled"));
 
 	controller_nh.param("steering_angle_absolute_value_limit", steering_angle_absolute_value_limit_, steering_angle_absolute_value_limit_);
     ROS_INFO_STREAM_NAMED(name_, "Steering angle limit is " << steering_angle_absolute_value_limit_);
@@ -297,6 +305,17 @@ namespace diff_drive_steering_controller{
     right_steering_joint_ = pos_joint_if->getHandle(right_steering_name);  // throws on failure
 
     sub_command_ = controller_nh.subscribe("cmd_vel", 1, &DiffDriveSteeringController::cmdVelCallback, this);
+    if (enable_independent_steering_)
+    {
+      sub_steering_command_["right"] =
+          controller_nh.subscribe<std_msgs::Float64>("steering_cmd/right",
+          1,
+          boost::bind(&DiffDriveSteeringController::steeringCmdCallback, this, _1, "right"));
+      sub_steering_command_["left"] =
+          controller_nh.subscribe<std_msgs::Float64>("steering_cmd/left",
+          1,
+          boost::bind(&DiffDriveSteeringController::steeringCmdCallback, this, _1, "left"));
+    }
 
     // Initialize dynamic parameters
     DynamicParams dynamic_params;
@@ -314,6 +333,7 @@ namespace diff_drive_steering_controller{
     config.left_wheel_radius_multiplier  = left_wheel_radius_multiplier_;
     config.right_wheel_radius_multiplier = right_wheel_radius_multiplier_;
     config.wheel_separation_multiplier   = wheel_separation_multiplier_;
+    config.enable_independent_steering = enable_independent_steering_;
 
     config.publish_rate = publish_rate;
     config.enable_odom_tf = enable_odom_tf_;
@@ -415,14 +435,32 @@ namespace diff_drive_steering_controller{
     left_wheel_joint_.setCommand(vel_left);
     right_wheel_joint_.setCommand(vel_right);
 
-	double steering_angle = atan2(curr_cmd.vy, curr_cmd.vx);
-	if(steering_angle > M_PI / 2.0){
-		steering_angle -= M_PI;
-	}else if(steering_angle < -M_PI / 2.0){
-		steering_angle += M_PI;
-	}
-	left_steering_joint_.setCommand(steering_angle);
-	right_steering_joint_.setCommand(steering_angle);
+    if (!enable_independent_steering_)
+    {
+      double steering_angle = atan2(curr_cmd.vy, curr_cmd.vx);
+      if(steering_angle > M_PI / 2.0){
+        steering_angle -= M_PI;
+      }else if(steering_angle < -M_PI / 2.0){
+        steering_angle += M_PI;
+      }
+      steering_angle =
+          std::min(
+              std::max(steering_angle, -steering_angle_absolute_value_limit_),
+              steering_angle_absolute_value_limit_);
+      left_steering_joint_.setCommand(steering_angle);
+      right_steering_joint_.setCommand(steering_angle);
+    }
+    else
+    {
+      if (steering_target_angle_.find("left") != steering_target_angle_.end())
+      {
+        left_steering_joint_.setCommand(steering_target_angle_.at("left"));
+      }
+      if (steering_target_angle_.find("right") != steering_target_angle_.end())
+      {
+        right_steering_joint_.setCommand(steering_target_angle_.at("right"));
+      }
+    }
 
     time_previous_ = time;
   }
@@ -476,6 +514,22 @@ namespace diff_drive_steering_controller{
                              << "Lin x: "   << command_struct_.vx << ", "
                              << "Lin y: "   << command_struct_.vy << ", "
                              << "Stamp: " << command_struct_.stamp);
+    }
+    else
+    {
+      ROS_ERROR_NAMED(name_, "Can't accept new commands. Controller is not running.");
+    }
+  }
+
+  void DiffDriveSteeringController::steeringCmdCallback(const std_msgs::Float64ConstPtr& msg, const std::string& wheel_name)
+  {
+    if (isRunning())
+    {
+      steering_target_angle_[wheel_name] = msg->data;
+      steering_target_angle_[wheel_name] =
+          std::min(
+              std::max(steering_target_angle_[wheel_name], -steering_angle_absolute_value_limit_),
+              steering_angle_absolute_value_limit_);
     }
     else
     {


### PR DESCRIPTION
`steering_cmd/(right|left)`トピックで左右のステア角を独立して指定できるようにした
`enable_independent_steering_`がfalseだと元の挙動になる